### PR TITLE
Add webApplicationInfo section to app manifest schema

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -456,8 +456,9 @@
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "AAD application id of the app.",
-                    "maxLength": 64
+                    "description": "AAD application id of the app. This id must be a GUID.",
+                    "maxLength": 36,
+                    "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"
                 },
                 "resource": {
                     "type": "string",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -323,7 +323,7 @@
                         "description": "The url to use for configuring the connector using the inline configuration experience.",
                         "maxLength": 2048,
                         "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
-                    },                    
+                    },
                     "scopes": {
                         "type": "array",
                         "description": "Specifies whether the connector offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. Currently, only the team scope is supported.",
@@ -450,6 +450,34 @@
                 "type": "string",
                 "maxLength": 2048
             }
+        },
+        "webApplicationInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "AAD application id of the app.",
+                    "maxLength": 64
+                },
+                "resource": {
+                    "type": "string",
+                    "description": "Resource url of app for acquiring auth token for SSO.",
+                    "maxLength": 2048
+                },
+                "scopes": {
+                    "type": "array",
+                    "maxItems": 80,
+                    "items": {
+                        "type": "string",
+                        "maxLength": 56
+                    }
+                }
+            },
+            "required": [
+                "id",
+                "resource"
+            ],
+            "additionalProperties": false
         }
     },
     "required": [

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -463,14 +463,6 @@
                     "type": "string",
                     "description": "Resource url of app for acquiring auth token for SSO.",
                     "maxLength": 2048
-                },
-                "scopes": {
-                    "type": "array",
-                    "maxItems": 80,
-                    "items": {
-                        "type": "string",
-                        "maxLength": 56
-                    }
                 }
             },
             "required": [


### PR DESCRIPTION
This change adds the webApplicationInfo section to the app manifest schema allowing developers to provide a strong link between their Teams and AAD apps. This information will be used to streamline authentication flows for apps that use AAD as an identity provider and/or leverage Microsoft Graph APIs.