### PR TITLE
allow multi-command for compose extension

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -366,7 +366,7 @@
                     },
                     "commands": {
                         "type": "array",
-                        "maxItems": 1,
+                        "maxItems": 10,
                         "items": {
                             "type": "object",
                             "additionalProperties": false,


### PR DESCRIPTION
This change is to quickly patch the 1.3 manifest to allow multicommand for compose extension.