### PR TITLE
new fields to support mobile package

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -66,6 +66,12 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                // the below property can be avoided by reducing the size of the short property.
+                "tiny": {
+                    "type": "string",
+                    "description": "A short display name for the app.",
+                    "maxLength": 12
+                },
                 "short": {
                     "type": "string",
                     "description": "A short display name for the app.",
@@ -110,6 +116,11 @@
                     "description": "A relative file path to a transparent PNG outline icon. The border color needs to be white. Size 20x20.",
                     "maxLength": 2048
                 },
+                "selectedOutline": {
+                    "type": "string",
+                    "description": "A relative file path to a transparent PNG filled icon. The fill color needs to be white. Size 20x20.",
+                    "maxLength": 2048
+                },
                 "color": {
                     "type": "string",
                     "description": "A relative file path to a full color PNG icon. Size 96x96.",
@@ -125,6 +136,30 @@
             "type": "string",
             "description": "A color to use in conjunction with the icon. The value must be a valid HTML color code starting with '#', for example `#4464ee`.",
             "pattern": "^#[0-9a-fA-F]{6}$"
+        },
+        "mobilePackageUrl": {
+            // this should be a private field
+            "type": "string",
+            "description": "The codepush url to the React Native bundle for mobile. If this field is present, and the configurable or static tab support mobile platform, the react native bundle is used to render the tab content instead of the content url ",
+            "maxLength": 2048,
+            "pattern": "^codepush://"
+        },
+        "nativeAppInstallLinks": {
+            "additionalProperties": false,
+            "properties": {
+                "android" : {
+                    "type": "string",
+                    "description": "The url to the play store for this app.",
+                    "maxLength": 2048,
+                    "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+                },
+                "ios" : {
+                    "type": "string",
+                    "description": "The url to the play store for this app.",
+                    "maxLength": 2048,
+                    "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+                }
+            }
         },
         "configurableTabs": {
             "type": "array",
@@ -155,11 +190,24 @@
                                 "groupchat"
                             ]
                         }
+                    },
+                    "platforms": {
+                        "type": "array",
+                        "description": "Specifies the platform on which these tabs can be shown",
+                        "maxItems": 3,
+                        "items": {
+                            "enum": [
+                                "web",
+                                "desktop",
+                                "mobile"
+                            ]
+                        }
                     }
                 },
                 "required": [
                     "configurationUrl",
-                    "scopes"
+                    "scopes",
+                    "platforms"
                 ]
             }
         },
@@ -193,6 +241,11 @@
                         "maxLength": 2048,
                         "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
                     },
+                    "mobileUrl": { // TODO: should also add this to the configurableTabs settings in js sdk
+                        "type": "string",
+                        "description": "The url to deep link into native app or a mobile specific website url",
+                        "maxLength": 2048
+                    },
                     "scopes": {
                         "type": "array",
                         "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive. Currently static tabs are only supported in the 'personal' scope.",
@@ -203,13 +256,26 @@
                                 "personal"
                             ]
                         }
+                    },
+                    "platforms": {
+                        "type": "array",
+                        "description": "Specifies the platform on which these tabs can be shown",
+                        "maxItems": 3,
+                        "items": {
+                            "enum": [
+                                "web",
+                                "desktop",
+                                "mobile"
+                            ]
+                        }
                     }
                 },
                 "required": [
                     "entityId",
                     "name",
                     "contentUrl",
-                    "scopes"
+                    "scopes",
+                    "platforms"
                 ]
             }
         },


### PR DESCRIPTION
Added the new fields to support react native mobile packages.
1. Mobile app should be able to render tabs (static and configurable) using react native bundles if present.
2. mobile app should be able to download updated react native packages from codepush.
3. developer should have the option to restrict/ enable the tabs on specific platforms like mobile, web or desktop.
4. developer should be able to define a selected icon to be displayed in bottom bar of the mobile app.
5. developer should define a concise app name which can fit in the app bar. (~ max 10-12 chars)
6. developer should be able to provide mobile specific deep link urls ,  which can directly link to the native apps instead of routing through browser with regular http based urls.
7. developer should be able to declare the links to app store / platystore for android / ios , so that the teams app can provide option for the user to goto the store to download/ install the native apps on  respective platforms.