### PR TITLE
adding supported platforms field, tiny name and selected outline icon for tabs support on mobile

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -366,7 +366,7 @@
                     },
                     "commands": {
                         "type": "array",
-                        "maxItems": 1,
+                        "maxItems": 10,
                         "items": {
                             "type": "object",
                             "additionalProperties": false,

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -455,27 +455,6 @@
                 "type": "string",
                 "maxLength": 2048
             }
-        },
-        "webApplicationInfo": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "AAD application id of the app. This id must be a GUID.",
-                    "maxLength": 36,
-                    "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"
-                },
-                "resource": {
-                    "type": "string",
-                    "description": "Resource url of app for acquiring auth token for SSO.",
-                    "maxLength": 2048
-                }
-            },
-            "required": [
-                "id",
-                "resource"
-            ],
-            "additionalProperties": false
         }
     },
     "required": [

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -128,7 +128,7 @@
         },
         "configurableTabs": {
             "type": "array",
-            "description": "These are tabs users can optionally add to their channels and require extra configuration before they are added. Configurable tabs are not supported in the personal scope. Currently only one configurable tab per app is supported.",
+            "description": "These are tabs users can optionally add to their channels and 1:1 or group chats and require extra configuration before they are added. Configurable tabs are not supported in the personal scope. Currently only one configurable tab per app is supported.",
             "maxItems": 1,
             "items": {
                 "type": "object",
@@ -147,11 +147,12 @@
                     },
                     "scopes": {
                         "type": "array",
-                        "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive. Currently, configurable tabs are only supported in the teams scope.",
-                        "maxItems": 1,
+                        "description": "Specifies whether the tab offers an experience in the context of a channel in a team, in a 1:1 or group chat, or in an experience scoped to an individual user alone. These options are non-exclusive. Currently, configurable tabs are only supported in the teams and groupchats scopes.",
+                        "maxItems": 2,
                         "items": {
                             "enum": [
-                                "team"
+                                "team",
+                                "groupchat"
                             ]
                         }
                     }
@@ -237,12 +238,13 @@
                     },
                     "scopes": {
                         "type": "array",
-                        "description": "Specifies whether the bot offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive.",
-                        "maxItems": 2,
+                        "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a 1:1 or group chat, or in an experience scoped to an individual user alone. These options are non-exclusive.",
+                        "maxItems": 3,
                         "items": {
                             "enum": [
                                 "team",
-                                "personal"
+                                "personal",
+                                "groupchat"
                             ]
                         }
                     },

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -131,11 +131,6 @@
                     "description": "A relative file path to a transparent PNG outline icon. The border color needs to be white. Size 32x32.",
                     "maxLength": 2048
                 },
-                "selectedOutline": {
-                    "type": "string",
-                    "description": "A relative file path to a transparent PNG filled icon to be shown when the icon is in selected/ focused state. The fill color needs to be white. Size 32x32.",
-                    "maxLength": 2048
-                },
                 "color": {
                     "type": "string",
                     "description": "A relative file path to a full color PNG icon. Size 96x96.",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -328,7 +328,7 @@
                         "description": "The url to use for configuring the connector using the inline configuration experience.",
                         "maxLength": 2048,
                         "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
-                    },                    
+                    },
                     "scopes": {
                         "type": "array",
                         "description": "Specifies whether the connector offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. Currently, only the team scope is supported.",
@@ -455,6 +455,27 @@
                 "type": "string",
                 "maxLength": 2048
             }
+        },
+        "webApplicationInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "AAD application id of the app. This id must be a GUID.",
+                    "maxLength": 36,
+                    "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"
+                },
+                "resource": {
+                    "type": "string",
+                    "description": "Resource url of app for acquiring auth token for SSO.",
+                    "maxLength": 2048
+                }
+            },
+            "required": [
+                "id",
+                "resource"
+            ],
+            "additionalProperties": false
         }
     },
     "required": [

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -236,6 +236,11 @@
                         "description": "A value indicating whether or not the bot is a one-way notification only bot, as opposed to a conversational bot.",
                         "default": false
                     },
+                    "supportsFiles": {
+                        "type": "boolean",
+                        "description": "A value indicating whether the bot supports uploading/downloading of files.",
+                        "default": false
+                    },
                     "scopes": {
                         "type": "array",
                         "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a 1:1 or group chat, or in an experience scoped to an individual user alone. These options are non-exclusive.",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -15,7 +15,7 @@
                     "tablet"
                 ]
             },
-            "default" : ["web", "desktop"]
+            "default" : ["web", "desktop", "phone", "tablet"]
         }
     },
     "properties": {

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -3,6 +3,10 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
         "manifestVersion": {
             "type": "string",
             "description": "The version of the schema this manifest is using.",
@@ -60,7 +64,7 @@
         },
         "name": {
             "type": "object",
-            "additionalProperties": false,            
+            "additionalProperties": false,
             "properties": {
                 "short": {
                     "type": "string",
@@ -342,16 +346,10 @@
                         "description": "The Microsoft App ID specified for the bot powering the compose extension in the Bot Framework portal (https://dev.botframework.com/bots)",
                         "maxLength": 64
                     },
-                    "scopes": {
-                        "type": "array",
-                        "maxItems": 2,
-                        "items": {
-                            "enum": [
-                                "team",
-                                "personal"
-                            ],
-                            "description": "Specifies whether the compose extension offers an experience in the context of a channel in a team or an experience scoped to an individual user alone. These options are non-exclusive."
-                        }
+                    "canUpdateConfiguration": {
+                        "type": "boolean",
+                        "description": "A value indicating whether the configuration of a compose extension can be updated by the user.",
+                        "default": false
                     },
                     "commands": {
                         "type": "array",
@@ -421,7 +419,6 @@
                 },
                 "required": [
                     "botId",
-                    "scopes",
                     "commands"
                 ]
             }

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -2,6 +2,22 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "additionalProperties": false,
+    "definitions" : {
+        "platforms" : {
+            "type": "array",
+            "description": "This section defines the different environments supported by Teams application. 1. web refers to the Teams website running in a web browser on any compatible device/ computer. 2. Desktop refers to the installed package of Teams application on devices/ machines running Windows or Mac OS 3. phone refers to native apps (apk or ipa) running on Android or IOS Phone devices like iPhone, etc. 4. tablet refers to native apps (apk or ipa) running on Android or IOS Tablet devices like iPad, etc",
+            "maxItems": 4,
+            "items": {
+                "enum": [
+                    "web",
+                    "desktop",
+                    "phone",
+                    "tablet"
+                ]
+            },
+            "default" : ["web", "desktop"]
+        }
+    },
     "properties": {
         "$schema": {
             "type": "string",
@@ -66,6 +82,11 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "tiny": {
+                    "type": "string",
+                    "description": "A shorter display name of the app, used on devices such as phone or tablet. If not provided, short name will be truncated to fit.",
+                    "maxLength": 12
+                },
                 "short": {
                     "type": "string",
                     "description": "A short display name for the app.",
@@ -107,7 +128,12 @@
             "properties": {
                 "outline": {
                     "type": "string",
-                    "description": "A relative file path to a transparent PNG outline icon. The border color needs to be white. Size 20x20.",
+                    "description": "A relative file path to a transparent PNG outline icon. The border color needs to be white. Size 32x32.",
+                    "maxLength": 2048
+                },
+                "selectedOutline": {
+                    "type": "string",
+                    "description": "A relative file path to a transparent PNG filled icon to be shown when the icon is in selected/ focused state. The fill color needs to be white. Size 32x32.",
                     "maxLength": 2048
                 },
                 "color": {
@@ -155,6 +181,10 @@
                                 "groupchat"
                             ]
                         }
+                    },
+                    "platforms": { 
+                        "$ref": "#/definitions/platforms",
+                        "description": "Specifies the platforms on which configurable tabs are displayed"
                     }
                 },
                 "required": [
@@ -203,6 +233,10 @@
                                 "personal"
                             ]
                         }
+                    },
+                    "platforms": {
+                        "$ref": "#/definitions/platforms",
+                        "description": "Specifies the platforms on which staticTabs tabs are displayed"
                     }
                 },
                 "required": [

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -256,7 +256,7 @@
                     "commandLists": {
                         "type": "array",
                         "maxItems": 2,
-                        "description": "The list of commands that the bot supplies, including their usage, description, and the scope for which the commands are valid. A seperate command list should be used for each scope.",
+                        "description": "The list of commands that the bot supplies, including their usage, description, and the scope for which the commands are valid. A separate command list should be used for each scope.",
                         "items": {
                             "type": "object",
                             "additionalProperties": false,

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -298,11 +298,12 @@
                                 "scopes": {
                                     "type": "array",
                                     "description": "Specifies the scopes for which the command list is valid",
-                                    "maxItems": 2,
+                                    "maxItems": 3,
                                     "items": {
                                         "enum": [
                                             "team",
-                                            "personal"
+                                            "personal",
+                                            "groupchat"
                                         ]
                                     }
                                 },
@@ -529,6 +530,27 @@
                 "type": "string",
                 "maxLength": 2048
             }
+        },
+        "webApplicationInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "AAD application id of the app. This id must be a GUID.",
+                    "maxLength": 36,
+                    "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"
+                },
+                "resource": {
+                    "type": "string",
+                    "description": "Resource url of app for acquiring auth token for SSO.",
+                    "maxLength": 2048
+                }
+            },
+            "required": [
+                "id",
+                "resource"
+            ],
+            "additionalProperties": false
         }
     },
     "required": [

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -318,6 +318,12 @@
                         "description": "A unique identifier for the connector which matches its ID in the Connectors Developer Portal.",
                         "maxLength": 64
                     },
+                    "configurationUrl": {
+                        "type": "string",
+                        "description": "The url to use for configuring the connector using the inline configuration experience.",
+                        "maxLength": 2048,
+                        "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
+                    },                    
                     "scopes": {
                         "type": "array",
                         "description": "Specifies whether the connector offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. Currently, only the team scope is supported.",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -420,6 +420,31 @@
                                             "title"
                                         ]
                                     }
+                                },
+                                "taskInfo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "description": "Initial dialog title",
+                                            "maxLength": 64
+                                        },
+                                        "width": {
+                                            "type": "string",
+                                            "description": "Dialog width - either a number in pixels or default layout such as 'large', 'medium', or 'small'",
+                                            "maxLength": 16
+                                        },
+                                        "height": {
+                                            "type": "string",
+                                            "description": "Dialog height - either a number in pixels or default layout such as 'large', 'medium', or 'small'",
+                                            "maxLength": 16
+                                        },
+                                        "url": {
+                                            "type": "string",
+                                            "description": "Initial webview URL",
+                                            "maxLength": 2048
+                                        }
+                                    }
                                 }
                             },
                             "required": [

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -376,6 +376,11 @@
                                     "description": "Id of the command.",
                                     "maxLength": 64
                                 },
+                                "type": {
+                                    "type": "string",
+                                    "enum": [ "query", "action" ],
+                                    "description": "Type of the command"
+                                },
                                 "title": {
                                     "type": "string",
                                     "description": "Title of the command.",
@@ -391,6 +396,11 @@
                                     "description": "A boolean value that indicates if the command should be run once initially with no parameter.",
                                     "default": false
                                 },
+                                "fetchTask": {
+                                    "type": "boolean",
+                                    "description": "A boolean value that indicates if it should fetch task module dynamically",
+                                    "default": false
+                                },
                                 "parameters": {
                                     "type": "array",
                                     "maxItems": 5,
@@ -403,6 +413,11 @@
                                                 "type": "string",
                                                 "description": "Name of the parameter.",
                                                 "maxLength": 64
+                                            },
+                                            "inputType": {
+                                                "type": "string",
+                                                "enum": [ "text", "textarea", "number", "date", "time", "toggle" ],
+                                                "description": "Type of the parameter"
                                             },
                                             "title": {
                                                 "type": "string",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# What Is This?
+
+This repository is where the [JSON Schema](http://json-schema.org/) for the [Microsoft Teams application manifest](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) resides. The first line in a Teams app manifest.json file is a reference to this file so that it can be validated: `"$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.2/MicrosoftTeams.schema.json",`.
+
+Unless you are writing an app that reads/writes Microsoft Teams manifest.json files, you don't need to care about this.
+
+# Versioning
+
+If you do want to link to MicrosoftTeams.schema.json within your source, here's where to find specific versions.
+* **Released version**. https://developer.microsoft.com/en-us/json-schemas/teams/vX.X/MicrosoftTeams.schema.json, where X.X corresponds to 
+the version numbers listed in the [releases](https://github.com/OfficeDev/microsoft-teams-app-schema/releases); usually [Latest release](https://github.com/OfficeDev/microsoft-teams-app-schema/releases/latest).
+* **Next release (vNext)**. Generally, there is no reason to link to MicrosoftTeams.schema.json in the `master` branch directly. At any point in time, the version of `MicrosoftTeams.schema.json` in the `master` branch *may* match the [Latest release](https://github.com/OfficeDev/microsoft-teams-app-schema/releases/latest) or it may be a future version that will appear in [releases](https://github.com/OfficeDev/microsoft-teams-app-schema/releases) at a later date (vNext). If you do need to link to the vNext version, you can use this URL: https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/master/MicrosoftTeams.schema.json. 
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Unless you are writing an app that reads/writes Microsoft Teams manifest.json fi
 # Versioning
 
 If you do want to link to MicrosoftTeams.schema.json within your source, here's where to find specific versions.
-* **Released version.** https://developer.microsoft.com/en-us/json-schemas/teams/vX.X/MicrosoftTeams.schema.json, where X.X corresponds to 
-the version numbers listed in the [releases](https://github.com/OfficeDev/microsoft-teams-app-schema/releases); usually [Latest release](https://github.com/OfficeDev/microsoft-teams-app-schema/releases/latest).
-* **Developer Preview.** The [preview/DevPreview branch](https://github.com/OfficeDev/microsoft-teams-app-schema/tree/preview/DevPreview) contains the manifest matching features in [Microsoft Teams Devleoper Preview](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/dev-preview/developer-preview-features). If you need to link to this version, you can use this URL: <https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json>.
+* **Released version.** https://developer.microsoft.com/en-us/json-schemas/teams/vX.X/MicrosoftTeams.schema.json (the GitHub repository for which is [here](https://github.com/Microsoft/json-schemas)), where X.X corresponds to 
+the version numbers listed in the [releases](https://github.com/OfficeDev/microsoft-teams-app-schema/releases); usually [Latest release](https://github.com/OfficeDev/microsoft-teams-app-schema/releases/latest). 
+* **Developer Preview.** The [preview/DevPreview branch](https://github.com/OfficeDev/microsoft-teams-app-schema/tree/preview/DevPreview) contains the manifest matching features in [Microsoft Teams Developer Preview](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/dev-preview/developer-preview-features). If you need to link to this version, you can use this URL: <https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json>.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What Is This?
 
-This repository is where the [JSON Schema](http://json-schema.org/) for the [Microsoft Teams application manifest](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) resides. The first line in a Teams app manifest.json file is a reference to this file so that it can be validated: `"$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.2/MicrosoftTeams.schema.json",`.
+This repository is where the [JSON Schema](http://json-schema.org/) for the [Microsoft Teams application manifest](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) resides. The first line in a Teams app manifest.json file is a reference to this file so that it can be validated, e.g.: `"$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.3/MicrosoftTeams.schema.json",`.
 
 Unless you are writing an app that reads/writes Microsoft Teams manifest.json files, you don't need to care about this.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Unless you are writing an app that reads/writes Microsoft Teams manifest.json fi
 # Versioning
 
 If you do want to link to MicrosoftTeams.schema.json within your source, here's where to find specific versions.
-* **Released version**. https://developer.microsoft.com/en-us/json-schemas/teams/vX.X/MicrosoftTeams.schema.json, where X.X corresponds to 
+* **Released version.** https://developer.microsoft.com/en-us/json-schemas/teams/vX.X/MicrosoftTeams.schema.json, where X.X corresponds to 
 the version numbers listed in the [releases](https://github.com/OfficeDev/microsoft-teams-app-schema/releases); usually [Latest release](https://github.com/OfficeDev/microsoft-teams-app-schema/releases/latest).
-* **Next release (vNext)**. Generally, there is no reason to link to MicrosoftTeams.schema.json in the `master` branch directly. At any point in time, the version of `MicrosoftTeams.schema.json` in the `master` branch *may* match the [Latest release](https://github.com/OfficeDev/microsoft-teams-app-schema/releases/latest) or it may be a future version that will appear in [releases](https://github.com/OfficeDev/microsoft-teams-app-schema/releases) at a later date (vNext). If you do need to link to the vNext version, you can use this URL: https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/master/MicrosoftTeams.schema.json. 
+* **Developer Preview.** The [preview/DevPreview branch](https://github.com/OfficeDev/microsoft-teams-app-schema/tree/preview/DevPreview) contains the manifest matching features in [Microsoft Teams Devleoper Preview](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/dev-preview/developer-preview-features). If you need to link to this version, you can use this URL: <https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json>.
 
 # Contributing
 


### PR DESCRIPTION
adding supported platforms field, tiny name and selected outline icon for static tabs and channel tabs.

For review comments please also looks at https://github.com/OfficeDev/microsoft-teams-app-schema/pull/20 . Created a new PR to send the changes in a phased manner.