### PR TITLE
Adding default values for composeExtensions

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -433,7 +433,7 @@
                                         ], 
                                     },
                                     "description": "Context where the command would apply",
-                                    "default": "['compose','commandbox']"
+                                    "default": ["compose","commandbox"]
                                 },
                                 "title": {
                                     "type": "string",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -419,7 +419,8 @@
                                 "type": {
                                     "type": "string",
                                     "enum": [ "query", "action" ],
-                                    "description": "Type of the command"
+                                    "description": "Type of the command",
+                                    "default": "action"
                                 },
                                 "context": {
                                     "type": "array",
@@ -429,9 +430,10 @@
                                             "compose",
                                             "commandbox",
                                             "message"
-                                        ],
-                                        "description": "Context where the command would apply"
-                                    }
+                                        ], 
+                                    },
+                                    "description": "Context where the command would apply",
+                                    "default": "['compose','commandbox']"
                                 },
                                 "title": {
                                     "type": "string",


### PR DESCRIPTION
added default for:
 - composeExtensions.commands.type
 - composeExtensions.commands.context

Moved the description field to (what I think is) the correct level for composeExtensions.commands.context