### PR TITLE
Add new SharePoint-specific fileds to app manifest [master]

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -165,6 +165,7 @@
                         "type": "array",
                         "description": "Defines how your tab will be made available in SharePoint.",
                         "maxItems": 2,
+                        "uniqueItems": true,
                         "items": {
                             "enum": [
                                 "sharePointFullPage",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -155,6 +155,22 @@
                                 "groupchat"
                             ]
                         }
+                    },
+                    "sharePointPreviewImage": {
+                        "type": "string",
+                        "description": "A relative file path to a tab preview image for use in SharePoint. Size 1024x768.",
+                        "maxLength": 2048
+                    },
+                    "supportedSharePointHosts": {
+                        "type": "array",
+                        "description": "Defines how your tab will be made available in SharePoint.",
+                        "maxItems": 2,
+                        "items": {
+                            "enum": [
+                                "sharePointFullPage",
+                                "sharePointWebPart"
+                            ]
+                        }
                     }
                 },
                 "required": [


### PR DESCRIPTION
This change adds the following new fields to the configuredTabs entries of the Teams app manifest:
- `sharePointPreviewImage` - A relative file path to a tab preview image for use in SharePoint. Size 1024x768.
- `supportedSharePointHosts` - Defines how your tab will be made available in SharePoint. Options are `sharePointFullPage` and `sharePointFullPage`.
