### PR TITLE
Fixing casing of message handler type

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -555,7 +555,7 @@
                                 "type": {
                                     "type": "string",
                                     "enum": [
-                                        "Link"
+                                        "link"
                                     ],
                                     "description": "Type of the message handler"
                                 },


### PR DESCRIPTION
It should have been lower cased, i.e. 'link'