### PR TITLE
Add taskinfo parameter to devPreview manifest schema

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -536,7 +536,33 @@
                                             "title"
                                         ]
                                     }
-                                }
+                                },
+                                "taskInfo": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "title": {
+                                        "type": "string",
+                                        "description": "Initial dialog title",
+                                        "maxLength": 64
+                                      },
+                                      "width": {
+                                        "type": "string",
+                                        "description": "Dialog width - either a number in pixels or default layout such as 'large', 'medium', or 'small'",
+                                        "maxLength": 16
+                                      },
+                                      "height": {
+                                        "type": "string",
+                                        "description": "Dialog height - either a number in pixels or default layout such as 'large', 'medium', or 'small'",
+                                        "maxLength": 16
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "description": "Initial webview URL",
+                                        "maxLength": 2048
+                                      }
+                                    }
+                                  }                                
                             },
                             "required": [
                                 "id",


### PR DESCRIPTION
Per the discussion, we should allow taskInfo be specified for everyone.