### PR TITLE
Make type on compose extensions required

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -582,7 +582,8 @@
                             },
                             "required": [
                                 "id",
-                                "title"
+                                "title",
+                                "type"
                             ]
                         }
                     },


### PR DESCRIPTION
This change is temporary until we roll out the fix to dev preview schema parsing in the Teams client.