### PR TITLE
Update staticTab rules to allow custom ordering of tabs

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -271,10 +271,6 @@
                 "description": "A unique identifier for the entity which the tab displays.",
                 "maxLength": 64
               },
-              "websiteUrl": {
-                "$ref": "#/definitions/httpsUrl",
-                "description": "The url to point at if a user opts to view in a browser."
-              },
               "scopes": {
                 "type": "array",
                 "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive. Currently static tabs are only supported in the 'personal' scope.",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -212,45 +212,86 @@
       "type": "array",
       "description": "A set of tabs that may be 'pinned' by default, without the user adding them manually. Static tabs declared in personal scope are always pinned to the app's personal experience. Static tabs do not currently support the 'teams' scope.",
       "maxItems": 16,
+      "uniqueItems": true,
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "entityId": {
-            "type": "string",
-            "description": "A unique identifier for the entity which the tab displays.",
-            "maxLength": 64
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "entityId": {
+                "type": "string",
+                "description": "A unique identifier for the entity which the tab displays.",
+                "maxLength": 64,
+                "pattern": "(?!^chat$|^about$)(^.*$)"
+              },
+              "name": {
+                "type": "string",
+                "description": "The display name of the tab.",
+                "maxLength": 128
+              },
+              "contentUrl": {
+                "$ref": "#/definitions/httpsUrl",
+                "description": "The url which points to the entity UI to be displayed in the Teams canvas."
+              },
+              "websiteUrl": {
+                "$ref": "#/definitions/httpsUrl",
+                "description": "The url to point at if a user opts to view in a browser."
+              },
+              "scopes": {
+                "type": "array",
+                "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive. Currently static tabs are only supported in the 'personal' scope.",
+                "maxItems": 2,
+                "items": {
+                  "enum": [
+                    "team",
+                    "personal"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "entityId",
+              "name",
+              "contentUrl",
+              "scopes"
+            ]
           },
-          "name": {
-            "type": "string",
-            "description": "The display name of the tab.",
-            "maxLength": 128
-          },
-          "contentUrl": {
-            "$ref": "#/definitions/httpsUrl",
-            "description": "The url which points to the entity UI to be displayed in the Teams canvas."
-          },
-          "websiteUrl": {
-            "$ref": "#/definitions/httpsUrl",
-            "description": "The url to point at if a user opts to view in a browser."
-          },
-          "scopes": {
-            "type": "array",
-            "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive. Currently static tabs are only supported in the 'personal' scope.",
-            "maxItems": 2,
-            "items": {
-              "enum": [
-                "team",
-                "personal"
-              ]
-            }
+          {
+            "additionalProperties": false,
+            "properties": {
+              "entityId": {
+                "type": "string",
+                "enum": [
+                  "chat",
+                  "about",
+                  "recent",
+                  "all"
+                ],
+                "description": "A unique identifier for the entity which the tab displays.",
+                "maxLength": 64
+              },
+              "websiteUrl": {
+                "$ref": "#/definitions/httpsUrl",
+                "description": "The url to point at if a user opts to view in a browser."
+              },
+              "scopes": {
+                "type": "array",
+                "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone. These options are non-exclusive. Currently static tabs are only supported in the 'personal' scope.",
+                "maxItems": 2,
+                "items": {
+                  "enum": [
+                    "team",
+                    "personal"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "entityId",
+              "scopes"
+            ]
           }
-        },
-        "required": [
-          "entityId",
-          "name",
-          "contentUrl",
-          "scopes"
         ]
       }
     },


### PR DESCRIPTION
update staticTab rules to restrict duplicate entityIds, allow placeholders without names and contentUrls for specified entityIds, and disallow the keywords "chat" and "about" as entityIds