### PR TITLE
Restrict XLL filename to non-whitespace characters using JavaScript-compatible regex

### DIFF
--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -2586,7 +2586,7 @@
       "properties": {
         "fileName": {
           "type": "string",
-          "pattern": "^(?!.*[\\r\\n\\f\\b\\v\\a\\t])[\\S]*\\.xll$",
+          "pattern": "^[^\\s]*\\.xll$",
           "minLength": 1,
           "maxLength": 64
         }


### PR DESCRIPTION
This PR updates the extensionXllCustomFunctions.fileName property validation regex in the schema to use a simpler, JavaScript-compatible pattern: ^[^\\s]*\\.xll$. This ensures that XLL filenames cannot contain any whitespace characters, and improves compatibility with JavaScript libraries. The previous pattern has been replaced to avoid unsupported control character escapes and simplify validation logic.