### PR TITLE
Update Teams App Manifest schema to v1.26

### DIFF
--- a/MicrosoftTeams.Localization.schema.json
+++ b/MicrosoftTeams.Localization.schema.json
@@ -89,7 +89,15 @@
       "type": "string",
       "maxLength": 128
     },
+    "^activities.activityGroups\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.displayName$": {
+      "type": "string",
+      "maxLength": 128
+    },
     "^meetingExtensionDefinition.scenes\\[[0-9]\\]\\.name$": {
+      "type": "string",
+      "maxLength": 128
+    },
+    "^meetingExtensionDefinition.videoFilters\\[([0-9]|1[0-5])\\]\\.name$": {
       "type": "string",
       "maxLength": 128
     },
@@ -113,7 +121,7 @@
       "type": "string",
       "maxLength": 32
     },
-    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.icons\\[[0-2]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -121,7 +129,7 @@
       "type": "string",
       "maxLength": 64
     },
-    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -137,7 +145,7 @@
       "type": "string",
       "maxLength": 250
     },
-    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -201,7 +209,7 @@
       "type": "string",
       "maxLength": 2048
     },
-    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.actions\\[[1]?[0-9]\\]\\.displayName$": {
+    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.actions\\[(1[0-4][0-9]|[1-9]?[0-9])\\]\\.displayName$": {
       "type": "string",
       "maxLength": 64
     },
@@ -225,6 +233,10 @@
       "type": "string",
       "maxLength": 128
     },
+    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.namespace\\.name$": {
+      "type": "string",
+      "maxLength": 32
+    },
     "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.enums\\[[0-9]\\]\\.values\\[[0-9]\\]\\.name$": {
       "type": "string",
       "maxLength": 256
@@ -232,10 +244,6 @@
     "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.enums\\[[0-9]\\]\\.values\\[[0-9]\\]\\.tooltip$": {
       "type": "string",
       "maxLength": 256
-    },
-    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.namespace\\.name$": {
-      "type": "string",
-      "maxLength": 32
     },
     "^extensions\\[[0]\\]\\.keyboardShortcuts\\[[0-9]\\]\\.shortcuts\\[[0-9]\\]\\.key\\.default$": {
       "type": "string",
@@ -273,11 +281,7 @@
       "type": "string",
       "maxLength": 2048
     },
-    "^extensions\\[[0]\\]\\.contentRuntimes\\[[1]?[0-9]\\]\\.code\\.page$": {
-      "type": "string",
-      "maxLength": 2048
-    },
-    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url": {
+    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -293,7 +297,7 @@
       "type": "string",
       "maxLength": 250
     },
-    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url": {
+    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url": {
       "type": "string",
       "maxLength": 2048
     },
@@ -309,6 +313,10 @@
       "type": "string",
       "maxLength": 250
     },
+    "^extensions\\[[0]\\]\\.contentRuntimes\\[[1]?[0-9]\\]\\.code\\.page$": {
+      "type": "string",
+      "maxLength": 2048
+    },
     "^copilotAgents.customEngineAgents\\[0\\]\\.disclaimer.text$": {
       "type": "string",
       "maxLength": 500
@@ -322,7 +330,11 @@
       "maxLength": 120
     }
   },
-  "required": [ "name.short", "description.short", "description.full" ],
+  "required": [
+    "name.short",
+    "description.short",
+    "description.full"
+  ],
   "definitions": {
     "nonEmptyString": {
       "type": "string",

--- a/MicrosoftTeams.Localization.schema.json
+++ b/MicrosoftTeams.Localization.schema.json
@@ -89,15 +89,7 @@
       "type": "string",
       "maxLength": 128
     },
-    "^activities.activityGroups\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.displayName$": {
-      "type": "string",
-      "maxLength": 128
-    },
     "^meetingExtensionDefinition.scenes\\[[0-9]\\]\\.name$": {
-      "type": "string",
-      "maxLength": 128
-    },
-    "^meetingExtensionDefinition.videoFilters\\[([0-9]|1[0-5])\\]\\.name$": {
       "type": "string",
       "maxLength": 128
     },
@@ -121,7 +113,7 @@
       "type": "string",
       "maxLength": 32
     },
-    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.icons\\[[0-2]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -129,7 +121,7 @@
       "type": "string",
       "maxLength": 64
     },
-    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -145,7 +137,7 @@
       "type": "string",
       "maxLength": 250
     },
-    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.ribbons\\[[0-9]\\]\\.tabs\\[[1]?[0-9]\\]\\.groups\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
     },
@@ -209,7 +201,7 @@
       "type": "string",
       "maxLength": 2048
     },
-    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.actions\\[(1[0-4][0-9]|[1-9]?[0-9])\\]\\.displayName$": {
+    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.actions\\[[1]?[0-9]\\]\\.displayName$": {
       "type": "string",
       "maxLength": 64
     },
@@ -233,10 +225,6 @@
       "type": "string",
       "maxLength": 128
     },
-    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.namespace\\.name$": {
-      "type": "string",
-      "maxLength": 32
-    },
     "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.enums\\[[0-9]\\]\\.values\\[[0-9]\\]\\.name$": {
       "type": "string",
       "maxLength": 256
@@ -244,6 +232,10 @@
     "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.enums\\[[0-9]\\]\\.values\\[[0-9]\\]\\.tooltip$": {
       "type": "string",
       "maxLength": 256
+    },
+    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.namespace\\.name$": {
+      "type": "string",
+      "maxLength": 32
     },
     "^extensions\\[[0]\\]\\.keyboardShortcuts\\[[0-9]\\]\\.shortcuts\\[[0-9]\\]\\.key\\.default$": {
       "type": "string",
@@ -281,7 +273,11 @@
       "type": "string",
       "maxLength": 2048
     },
-    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
+    "^extensions\\[[0]\\]\\.contentRuntimes\\[[1]?[0-9]\\]\\.code\\.page$": {
+      "type": "string",
+      "maxLength": 2048
+    },
+    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url": {
       "type": "string",
       "maxLength": 2048
     },
@@ -297,7 +293,7 @@
       "type": "string",
       "maxLength": 250
     },
-    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url": {
+    "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.items\\[[1]?[0-9]\\]\\.icons\\[[0-2]\\]\\.url": {
       "type": "string",
       "maxLength": 2048
     },
@@ -313,10 +309,6 @@
       "type": "string",
       "maxLength": 250
     },
-    "^extensions\\[[0]\\]\\.contentRuntimes\\[[1]?[0-9]\\]\\.code\\.page$": {
-      "type": "string",
-      "maxLength": 2048
-    },
     "^copilotAgents.customEngineAgents\\[0\\]\\.disclaimer.text$": {
       "type": "string",
       "maxLength": 500
@@ -330,11 +322,7 @@
       "maxLength": 120
     }
   },
-  "required": [
-    "name.short",
-    "description.short",
-    "description.full"
-  ],
+  "required": [ "name.short", "description.short", "description.full" ],
   "definitions": {
     "nonEmptyString": {
       "type": "string",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -1450,6 +1450,11 @@
       "maxLength": 2048,
       "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
     },
+    "anyHttpUrl": {
+        "type": "string",
+        "maxLength": 2048,
+        "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+    },
     "secureHttpUrl": {
       "type": "string",
       "maxLength": 2048,

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -1352,7 +1352,18 @@
         }
       },
       "additionalProperties": false,
-      "anyOf": []
+      "oneOf": [
+        {
+          "required": [
+            "declarativeAgents"
+          ]
+        },
+        {
+          "required": [
+            "customEngineAgents"
+          ]
+        }
+      ]
     },
     "agenticUserTemplates": {
       "type": "array",
@@ -1438,11 +1449,6 @@
       "type": "string",
       "maxLength": 2048,
       "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
-    },
-    "anyHttpUrl": {
-        "type": "string",
-        "maxLength": 2048,
-        "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
     },
     "secureHttpUrl": {
       "type": "string",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -1450,11 +1450,6 @@
       "maxLength": 2048,
       "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
     },
-    "anyHttpUrl": {
-        "type": "string",
-        "maxLength": 2048,
-        "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
-    },
     "secureHttpUrl": {
       "type": "string",
       "maxLength": 2048,


### PR DESCRIPTION
## Summary

Updates the Teams App Manifest schema files to v1.26.

Generated by the App Manifest Schema Publisher.