### PR TITLE
Update Teams App Manifest schema to v1.27

### DIFF
--- a/MicrosoftTeams.Localization.schema.json
+++ b/MicrosoftTeams.Localization.schema.json
@@ -81,6 +81,10 @@
       "type": "string",
       "maxLength": 64
     },
+    "^composeExtensions\\[0\\]\\.commands\\[[0-9]\\]\\.prompt$": {
+      "type": "string",
+      "maxLength": 4000
+    },
     "^activities.activityTypes\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.description$": {
       "type": "string",
       "maxLength": 128
@@ -89,15 +93,7 @@
       "type": "string",
       "maxLength": 128
     },
-    "^activities.activityGroups\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.displayName$": {
-      "type": "string",
-      "maxLength": 128
-    },
     "^meetingExtensionDefinition.scenes\\[[0-9]\\]\\.name$": {
-      "type": "string",
-      "maxLength": 128
-    },
-    "^meetingExtensionDefinition.videoFilters\\[([0-9]|1[0-5])\\]\\.name$": {
       "type": "string",
       "maxLength": 128
     },
@@ -233,10 +229,6 @@
       "type": "string",
       "maxLength": 128
     },
-    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.namespace\\.name$": {
-      "type": "string",
-      "maxLength": 32
-    },
     "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.enums\\[[0-9]\\]\\.values\\[[0-9]\\]\\.name$": {
       "type": "string",
       "maxLength": 256
@@ -244,6 +236,10 @@
     "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.enums\\[[0-9]\\]\\.values\\[[0-9]\\]\\.tooltip$": {
       "type": "string",
       "maxLength": 256
+    },
+    "^extensions\\[[0]\\]\\.runtimes\\[[1]?[0-9]\\]\\.customFunctions\\.namespace\\.name$": {
+      "type": "string",
+      "maxLength": 32
     },
     "^extensions\\[[0]\\]\\.keyboardShortcuts\\[[0-9]\\]\\.shortcuts\\[[0-9]\\]\\.key\\.default$": {
       "type": "string",
@@ -281,6 +277,10 @@
       "type": "string",
       "maxLength": 2048
     },
+    "^extensions\\[[0]\\]\\.contentRuntimes\\[[1]?[0-9]\\]\\.code\\.page$": {
+      "type": "string",
+      "maxLength": 2048
+    },
     "^extensions\\[[0]\\]\\.contextMenus\\[[0-9]\\]\\.menus\\[[0-9]\\]\\.controls\\[[1]?[0-9]\\]\\.icons\\[[0-7]\\]\\.url$": {
       "type": "string",
       "maxLength": 2048
@@ -313,13 +313,17 @@
       "type": "string",
       "maxLength": 250
     },
-    "^extensions\\[[0]\\]\\.contentRuntimes\\[[1]?[0-9]\\]\\.code\\.page$": {
-      "type": "string",
-      "maxLength": 2048
-    },
     "^copilotAgents.customEngineAgents\\[0\\]\\.disclaimer.text$": {
       "type": "string",
       "maxLength": 500
+    },
+    "^agentConnectors\\[[0-9]\\]\\.displayName$": {
+      "type": "string",
+      "maxLength": 128
+    },
+    "^agentConnectors\\[[0-9]\\]\\.description$": {
+      "type": "string",
+      "maxLength": 4000
     },
     "^description\\.features\\[[0-2]+\\]\\.title$": {
       "type": "string",
@@ -330,11 +334,7 @@
       "maxLength": 120
     }
   },
-  "required": [
-    "name.short",
-    "description.short",
-    "description.full"
-  ],
+  "required": [ "name.short", "description.short", "description.full" ],
   "definitions": {
     "nonEmptyString": {
       "type": "string",

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -3092,7 +3092,7 @@
         "fileName": {
           "type": "string",
           "description": "File name for the XLL extension. Maximum length is 254 characters.",
-          "pattern": "^(?!.*[\\r\\n\\f\\b\\v\\a\\t])[\\S]*\\.xll$",
+          "pattern": "^(?!.*[\\r\\n\\f\\b\\v\\u0007\\t])[\\S]*\\.xll$",
           "minLength": 4,
           "maxLength": 254
         }

--- a/MicrosoftTeams.schema.json
+++ b/MicrosoftTeams.schema.json
@@ -10,7 +10,7 @@
     "manifestVersion": {
       "type": "string",
       "description": "The version of the schema this manifest is using. This schema version supports extending Teams apps to other parts of the Microsoft 365 ecosystem. More info at https://aka.ms/extendteamsapps.",
-      "const": "1.26"
+      "const": "1.27"
     },
     "version": {
       "type": "string",
@@ -57,7 +57,7 @@
           }
         }
       },
-      "required": [
+            "required": [
         "defaultLanguageTag"
       ]
     },
@@ -95,7 +95,7 @@
         "termsOfUseUrl"
       ]
     },
-    "name": {
+        "name": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -114,7 +114,7 @@
         "short"
       ]
     },
-    "description": {
+      "description": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -142,7 +142,7 @@
                 "maxLength": 45,
                 "description": "Title of the feature the app provides."
               },
-              "description": {
+                "description": {
                 "type": "string",
                 "maxLength": 120,
                 "description": "Detailed description of the specific feature."
@@ -155,7 +155,7 @@
           }
         }
       },
-      "required": [
+            "required": [
         "short",
         "full"
       ]
@@ -184,7 +184,7 @@
     },
     "accentColor": {
       "$ref": "#/definitions/hexColor",
-      "description": "A color to use in conjunction with the icon. The value must be a valid HTML color code starting with '#', for example `#4464ee`."
+      "description": "A color to use in conjunction with the icon. The value must be a valid HTML color code starting with \u0027#\u0027, for example \u0060#4464ee\u0060."
     },
     "configurableTabs": {
       "type": "array",
@@ -205,7 +205,7 @@
           },
           "canUpdateConfiguration": {
             "type": "boolean",
-            "description": "A value indicating whether an instance of the tab's configuration can be updated by the user after creation.",
+            "description": "A value indicating whether an instance of the tab\u0027s configuration can be updated by the user after creation.",
             "default": true
           },
           "scopes": {
@@ -271,7 +271,7 @@
     },
     "staticTabs": {
       "type": "array",
-      "description": "A set of tabs that may be 'pinned' by default, without the user adding them manually. Static tabs declared in personal scope are always pinned to the app's personal experience. Static tabs do not currently support the 'teams' scope.",
+      "description": "A set of tabs that may be \u0027pinned\u0027 by default, without the user adding them manually. Static tabs declared in personal scope are always pinned to the app\u0027s personal experience. Static tabs do not currently support the \u0027teams\u0027 scope.",
       "maxItems": 16,
       "uniqueItems": true,
       "items": {
@@ -302,11 +302,11 @@
           },
           "searchUrl": {
             "$ref": "#/definitions/httpsUrl",
-            "description": "The url to direct a user's search queries."
+            "description": "The url to direct a user\u0027s search queries."
           },
           "scopes": {
             "type": "array",
-            "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone or group chat. These options are non-exclusive. Currently static tabs are only supported in the 'personal' scope.",
+            "description": "Specifies whether the tab offers an experience in the context of a channel in a team, or an experience scoped to an individual user alone or group chat. These options are non-exclusive. Currently static tabs are only supported in the \u0027personal\u0027 scope.",
             "maxItems": 3,
             "items": {
               "enum": [
@@ -447,20 +447,31 @@
                         "description": "The bot command name",
                         "maxLength": 128
                       },
-                      "description": {
+                        "description": {
                         "type": "string",
                         "description": "A simple text description or an example of the command syntax and its arguments.",
                         "maxLength": 4000
+                      },
+                        "type": {
+                        "type": "string",
+                        "enum": [ "basic", "prompt"
+ ],
+                        "description": "Type of the command. Default is basic",
+                        "default": "basic"
+                      },
+                        "prompt": {
+                        "type": "string",
+                        "maxLength": 4000,
+                        "description": "The prompt text to be used by Teams when user initiates the command from one of the entry points"
                       }
                     },
                     "required": [
-                      "title",
-                      "description"
+                      "title"
                     ]
                   }
                 }
               },
-              "required": [
+                    "required": [
                 "scopes",
                 "commands"
               ]
@@ -470,41 +481,37 @@
             "$ref": "#/definitions/elementRequirementSet"
           },
           "registrationInfo": {
-            "description": "System‑generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
+            "description": "System\u2011generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
             "type": "object",
             "properties": {
               "source": {
                 "type": "string",
-                "enum": [
-                  "standard",
-                  "microsoftCopilotStudio",
-                  "onedriveSharepoint"
-                ],
-                "description": "The partner source through which the bot is registered. System‑generated metadata. This information is maintained by Microsoft services and must not be modified manually."
+                "enum": [ "standard", "microsoftCopilotStudio", "onedriveSharepoint"
+ ],
+                "description": "The partner source through which the bot is registered. System\u2011generated metadata. This information is maintained by Microsoft services and must not be modified manually."
               },
               "environment": {
                 "type": "string",
-                "description": "A Power Platform environment that serves as a container for building apps under a Microsoft 365 tenant and can only be accessed by users within that tenant. System‑generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
+                "description": "A Power Platform environment that serves as a container for building apps under a Microsoft 365 tenant and can only be accessed by users within that tenant. System\u2011generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
                 "maxLength": 128
               },
               "schemaName": {
                 "type": "string",
-                "description": "The Copilot Studio copilot schema name. System‑generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
+                "description": "The Copilot Studio copilot schema name. System\u2011generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
                 "maxLength": 128
               },
               "clusterCategory": {
                 "type": "string",
-                "description": "The core services cluster category for Copilot Studio copilots. System‑generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
+                "description": "The core services cluster category for Copilot Studio copilots. System\u2011generated metadata. This information is maintained by Microsoft services and must not be modified manually.",
                 "maxLength": 128
               }
             },
-            "required": [
-              "source"
-            ],
+            "required": [ "source"
+ ],
             "additionalProperties": false
           }
         },
-        "required": [
+                    "required": [
           "botId",
           "scopes"
         ]
@@ -625,7 +632,7 @@
               },
               "oAuthConfiguration": {
                 "type": "object",
-                "description": "Object capturing details needed to match the application's OAuth configuration for the app. This should be and must be populated only when authType is set to oAuth2.0r",
+                "description": "Object capturing details needed to match the application\u0027s OAuth configuration for the app. This should be and must be populated only when authType is set to oAuth2.0r",
                 "properties": {
                   "oAuthConfigurationId": {
                     "type": "string",
@@ -636,17 +643,15 @@
                 "additionalProperties": false
               }
             },
-            "additionalProperties": false
+                "additionalProperties": false
           },
           "apiSpecificationFile": {
             "$ref": "#/definitions/relativePath",
             "description": "A relative file path to the api specification file in the manifest package."
           },
           "canUpdateConfiguration": {
-            "type": [
-              "boolean",
-              "null"
-            ],
+            "type": [ "boolean", "null"
+ ],
             "description": "A value indicating whether the configuration of a compose extension can be updated by the user.",
             "default": "null"
           },
@@ -662,7 +667,7 @@
                   "description": "Id of the command.",
                   "maxLength": 64
                 },
-                "type": {
+                  "type": {
                   "type": "string",
                   "enum": [
                     "query",
@@ -715,7 +720,7 @@
                   "description": "Title of the command.",
                   "maxLength": 32
                 },
-                "description": {
+                  "description": {
                   "type": "string",
                   "description": "Description of the command.",
                   "maxLength": 128
@@ -762,7 +767,7 @@
                         "description": "Title of the parameter.",
                         "maxLength": 32
                       },
-                      "description": {
+                        "description": {
                         "type": "string",
                         "description": "Description of the parameter.",
                         "maxLength": 128
@@ -808,7 +813,7 @@
                         "maxLength": 2000
                       }
                     },
-                    "required": [
+                          "required": [
                       "name",
                       "title"
                     ]
@@ -825,11 +830,11 @@
                     },
                     "width": {
                       "$ref": "#/definitions/taskInfoDimension",
-                      "description": "Dialog width - either a number in pixels or default layout such as 'large', 'medium', or 'small'"
+                      "description": "Dialog width - either a number in pixels or default layout such as \u0027large\u0027, \u0027medium\u0027, or \u0027small\u0027"
                     },
                     "height": {
                       "$ref": "#/definitions/taskInfoDimension",
-                      "description": "Dialog height - either a number in pixels or default layout such as 'large', 'medium', or 'small'"
+                      "description": "Dialog height - either a number in pixels or default layout such as \u0027large\u0027, \u0027medium\u0027, or \u0027small\u0027"
                     },
                     "url": {
                       "$ref": "#/definitions/httpsUrl",
@@ -837,13 +842,13 @@
                     }
                   }
                 },
-                "semanticDescription": {
+                      "semanticDescription": {
                   "type": "string",
                   "description": "Semantic description for the command.",
                   "maxLength": 5000
                 }
               },
-              "required": [
+                    "required": [
                 "id",
                 "title"
               ]
@@ -876,7 +881,7 @@
                     },
                     "supportsAnonymizedPayloads": {
                       "type": "boolean",
-                      "description": "A boolean that indicates whether the app's link message handler supports anonymous invoke flow.",
+                      "description": "A boolean that indicates whether the app\u0027s link message handler supports anonymous invoke flow.",
                       "default": false
                     }
                   },
@@ -887,7 +892,7 @@
                 "type",
                 "value"
               ],
-              "additionalProperties": false
+                  "additionalProperties": false
             }
           },
           "requirementSet": {
@@ -909,7 +914,7 @@
     },
     "devicePermissions": {
       "type": "array",
-      "description": "Specify the native features on a user's device that your app may request access to.",
+      "description": "Specify the native features on a user\u0027s device that your app may request access to.",
       "maxItems": 5,
       "items": {
         "enum": [
@@ -923,7 +928,7 @@
     },
     "validDomains": {
       "type": "array",
-      "description": "A list of valid domains from which the tabs expect to load any content. Domain listings can include wildcards, for example `*.example.com`. If your tab configuration or content UI needs to navigate to any other domain besides the one use for tab configuration, that domain must be specified here.",
+      "description": "A list of valid domains from which the tabs expect to load any content. Domain listings can include wildcards, for example \u0060*.example.com\u0060. If your tab configuration or content UI needs to navigate to any other domain besides the one use for tab configuration, that domain must be specified here.",
       "maxItems": 16,
       "items": {
         "type": "string",
@@ -952,7 +957,7 @@
             "properties": {
               "redirectUri": {
                 "type": "string",
-                "description": "Represents the nested app's valid redirect URI (always a base origin)."
+                "description": "Represents the nested app\u0027s valid redirect URI (always a base origin)."
               },
               "scopes": {
                 "type": "array",
@@ -964,26 +969,24 @@
               },
               "claims": {
                 "type": "string",
-                "description": "An optional JSON formatted object of client capabilities that represents if the resource server is CAE capable. Do not use an empty string for this value. If unsupported, keep the field undefined. If supported, use the following string exactly: '{\"access_token\":{\"xms_cc\":{\"values\":[\"CP1\"]}}}'. More info on client capabilities here: https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge?tabs=dotnet#how-to-communicate-client-capabilities-to-microsoft-entra-id ",
+                "description": "An optional JSON formatted object of client capabilities that represents if the resource server is CAE capable. Do not use an empty string for this value. If unsupported, keep the field undefined. If supported, use the following string exactly: \u0027{\u0022access_token\u0022:{\u0022xms_cc\u0022:{\u0022values\u0022:[\u0022CP1\u0022]}}}\u0027. More info on client capabilities here: https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge?tabs=dotnet#how-to-communicate-client-capabilities-to-microsoft-entra-id ",
                 "minLength": 1
               }
             },
-            "required": [
-              "redirectUri",
-              "scopes"
-            ],
+            "required": [ "redirectUri", "scopes"
+ ],
             "additionalProperties": false
           }
         }
       },
-      "required": [
+            "required": [
         "id"
       ],
-      "additionalProperties": false
+            "additionalProperties": false
     },
     "graphConnector": {
       "type": "object",
-      "description": "Specify the app's Graph connector configuration. If this is present then webApplicationInfo.id must also be specified.",
+      "description": "Specify the app\u0027s Graph connector configuration. If this is present then webApplicationInfo.id must also be specified.",
       "properties": {
         "notificationUrl": {
           "$ref": "#/definitions/httpsUrl",
@@ -1070,7 +1073,7 @@
           }
         }
       },
-      "additionalProperties": false
+            "additionalProperties": false
     },
     "supportsChannelFeatures": {
       "type": "string",
@@ -1082,7 +1085,7 @@
     },
     "supportedChannelTypes": {
       "type": "array",
-      "description": "List of 'non-standard' channel types that the app supports. Note: Channels of standard type are supported by default if the app supports team scope.",
+      "description": "List of \u0027non-standard\u0027 channel types that the app supports. Note: Channels of standard type are supported by default if the app supports team scope.",
       "maxItems": 2,
       "items": {
         "enum": [
@@ -1121,12 +1124,12 @@
     "defaultInstallScope": {
       "type": "string",
       "enum": [
-        "personal",
-        "team",
-        "groupChat",
-        "meetings",
-        "copilot"
-      ],
+  "personal",
+  "team",
+  "groupChat",
+  "meetings",
+  "copilot"
+],
       "description": "The install scope defined for this app by default. This will be the option displayed on the button when a user tries to add the app"
     },
     "defaultGroupCapability": {
@@ -1135,32 +1138,32 @@
         "team": {
           "type": "string",
           "enum": [
-            "tab",
-            "bot",
-            "connector"
-          ],
+  "tab",
+  "bot",
+  "connector"
+],
           "description": "When the install scope selected is Team, this field specifies the default capability available"
         },
         "groupchat": {
           "type": "string",
           "enum": [
-            "tab",
-            "bot",
-            "connector"
-          ],
+  "tab",
+  "bot",
+  "connector"
+],
           "description": "When the install scope selected is GroupChat, this field specifies the default capability available"
         },
         "meetings": {
           "type": "string",
           "enum": [
-            "tab",
-            "bot",
-            "connector"
-          ],
+  "tab",
+  "bot",
+  "connector"
+],
           "description": "When the install scope selected is Meetings, this field specifies the default capability available"
         }
       },
-      "description": "When a group install scope is selected, this will define the default capability when the user installs the app",
+          "description": "When a group install scope is selected, this will define the default capability when the user installs the app",
       "additionalProperties": false
     },
     "meetingExtensionDefinition": {
@@ -1210,12 +1213,12 @@
             ]
           },
           "maxItems": 5,
-          "type": "array",
+            "type": "array",
           "uniqueItems": true
         },
         "supportsStreaming": {
           "type": "boolean",
-          "description": "A boolean value indicating whether this app can stream the meeting's audio video content to an RTMP endpoint.",
+          "description": "A boolean value indicating whether this app can stream the meeting\u0027s audio video content to an RTMP endpoint.",
           "default": false
         },
         "supportsCustomShareToStage": {
@@ -1229,10 +1232,10 @@
           "default": false
         }
       },
-      "description": "Specify meeting extension definition.",
-      "additionalProperties": false
+          "description": "Specify meeting extension definition.",
+            "additionalProperties": false
     },
-    "authorization": {
+          "authorization": {
       "type": "object",
       "description": "Specify and consolidates authorization related information for the App.",
       "additionalProperties": false,
@@ -1256,7 +1259,7 @@
                     "description": "The name of the resource-specific permission.",
                     "maxLength": 128
                   },
-                  "type": {
+                    "type": {
                     "type": "string",
                     "enum": [
                       "Application",
@@ -1341,7 +1344,7 @@
                 ]
               }
             },
-            "required": [
+                "required": [
               "id",
               "type"
             ],
@@ -1351,8 +1354,19 @@
           "maxItems": 1
         }
       },
-      "additionalProperties": false,
-      "anyOf": []
+            "additionalProperties": false,
+      "oneOf": [
+  {
+    "required": [
+      "declarativeAgents"
+    ]
+  },
+  {
+    "required": [
+      "customEngineAgents"
+    ]
+  }
+]
     },
     "agenticUserTemplates": {
       "type": "array",
@@ -1384,7 +1398,7 @@
         }
       },
       "anyOf": [
-        {
+    {
           "required": [
             "oneWayDependencies"
           ]
@@ -1410,16 +1424,109 @@
               "description": "Required URL for background loading. This can be the same contentUrl from the staticTabs section or an alternative endpoint used for background loading."
             }
           },
-          "required": [
-            "contentUrl"
-          ],
+          "required": [ "contentUrl"
+ ],
           "additionalProperties": false
         }
       },
-      "additionalProperties": false
+          "additionalProperties": false
+    },
+    "agentConnectors": {
+      "type": "array",
+      "description": "A list of agent connector objects to included in the Unified App Manifest.",
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "description": "An agent connector represents a mechanism to enable agents to access information from systems outside of Microsoft 365, often via an MCP Server. Other mechanisms include using OpenAPI descriptions for calling external HTTP APIs. The role of the agent connector is to provide the necessary configuration information to agents or other M365 applications to connect to these external systems. An agent connector can be provided for use by other elements described within the same Unified App Manifest, or as a standalone resource that can be referenced in the Unified App Manifest of other M365 applications.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the agent connector",
+            "maxLength": 64
+          },
+          "displayName": {
+            "type": "string",
+            "description": "A user-friendly name for the connector, which can be displayed in UIs.",
+            "maxLength": 128
+          },
+            "description": {
+            "type": "string",
+            "description": "A brief description of the connector\u0027s purpose and functionality.",
+            "maxLength": 4000
+          },
+          "toolSource": {
+            "type": "object",
+            "description": "Configuration details for connectors that provide tools for agents via a remote MCP server.",
+            "properties": {
+              "remoteMcpServer": {
+                "type": "object",
+                "description": "Configuration details for a connector that provides tools via a remote MCP server.",
+                "additionalProperties": false,
+                "properties": {
+                  "mcpServerUrl": {
+                    "$ref": "#/definitions/secureHttpUrl",
+                    "description": "The URL of the remote MCP Server."
+                  },
+                  "mcpToolDescription": {
+                    "type": "object",
+                    "description": "Configuration for MCP tool descriptions, either by file reference or inline content (but not both). When this property is present it indicates that dynamic discovery will not be used.",
+                    "properties": {
+                      "file": {
+                        "$ref": "#/definitions/relativePath",
+                        "description": "The relative path to the MCP tool description file within the app package."
+                      }
+                    },
+                    "required": ["file"
+],
+                    "additionalProperties": false
+                  },
+                  "authorization": {
+                    "type": "object",
+                    "description": "Authorization configuration for connecting to the local MCP server. The design mirrors that of Plugin Manifests https://spec-hub.azurewebsites.net/specifications/PluginManifest-2.3.html",
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [ "None", "OAuthPluginVault", "ApiKeyPluginVault", "DynamicClientRegistration"
+ ],
+                        "description": "The type of authorization required to invoke the MCP server. Supported values are: \u0027None\u0027 (anonymous access), \u0027OAuthPluginVault\u0027 (OAuth flow with referenceId), \u0027ApiKeyPluginVault\u0027 (API Key with referenceId), \u0027DynamicClientRegistration\u0027 (dynamic client registration with referenceId)."
+                      },
+                      "referenceId": {
+                        "type": "string",
+                        "maxLength": 128,
+                        "description": "A reference identifier used when type is OAuthPluginVault, ApiKeyPluginVault, or DynamicClientRegistration. The referenceId value is acquired independently when providing the necessary authorization configuration values. This mechanism exists to prevent the need for storing secret values in the plugin manifest."
+                      }
+                    },
+                    "required": [ "type"
+ ],
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "enum": [ "OAuthPluginVault", "ApiKeyPluginVault", "DynamicClientRegistration"
+ ]
+                        }
+                      }
+                    },
+                    "then": {
+                      "required": [ "referenceId"
+ ]
+                    }
+                  }
+                },
+                    "required": [ "mcpServerUrl", "mcpToolDescription"
+ ]
+              }
+            },
+                "additionalProperties": false
+          }
+        },
+                    "required": [ "id", "displayName"
+ ],
+                "additionalProperties": false
+      }
     }
   },
-  "required": [
+            "required": [
     "manifestVersion",
     "version",
     "id",
@@ -1439,11 +1546,6 @@
       "maxLength": 2048,
       "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
     },
-    "anyHttpUrl": {
-        "type": "string",
-        "maxLength": 2048,
-        "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
-    },
     "secureHttpUrl": {
       "type": "string",
       "maxLength": 2048,
@@ -1452,7 +1554,7 @@
     "semver": {
       "type": "string",
       "maxLength": 256,
-      "pattern": "^([0-9]|[1-9]+[0-9]*)\\.([0-9]|[1-9]+[0-9]*)\\.([0-9]|[1-9]+[0-9]*)$"
+      "pattern": "^([0-9]|[1-9]\u002B[0-9]*)\\.([0-9]|[1-9]\u002B[0-9]*)\\.([0-9]|[1-9]\u002B[0-9]*)$"
     },
     "hexColor": {
       "type": "string",
@@ -1468,7 +1570,7 @@
     },
     "taskInfoDimension": {
       "type": "string",
-      "pattern": "^((([0-9]*\\.)?[0-9]+)|[lL][aA][rR][gG][eE]|[mM][eE][dD][iI][uU][mM]|[sS][mM][aA][lL][lL])$",
+      "pattern": "^((([0-9]*\\.)?[0-9]\u002B)|[lL][aA][rR][gG][eE]|[mM][eE][dD][iI][uU][mM]|[sS][mM][aA][lL][lL])$",
       "maxLength": 16
     },
     "elementReference": {
@@ -1519,7 +1621,7 @@
         "dependsOn"
       ],
       "additionalProperties": false,
-      "description": "An object representing a unidirectional dependency relationship, where one specific element (referred to as the `element`) relies on an array of other elements (referred to as the `dependsOn`) in a single direction."
+      "description": "An object representing a unidirectional dependency relationship, where one specific element (referred to as the \u0060element\u0060) relies on an array of other elements (referred to as the \u0060dependsOn\u0060) in a single direction."
     },
     "mutualDependency": {
       "type": "array",
@@ -1564,7 +1666,7 @@
         "name"
       ],
       "additionalProperties": false,
-      "description": "An object representing a specific functionality that a host must support."
+          "description": "An object representing a specific functionality that a host must support."
     },
     "elementExtensions": {
       "type": "array",
@@ -1600,7 +1702,7 @@
           },
           "keyboardShortcuts": {
             "type": "array",
-            "description": " Keyboard shortcuts, also known as key combinations, enable your add-in's users to work more efficiently. Keyboard shortcuts also improve the add-in's accessibility for users with disabilities by providing an alternative to the mouse.",
+            "description": " Keyboard shortcuts, also known as key combinations, enable your add-in\u0027s users to work more efficiently. Keyboard shortcuts also improve the add-in\u0027s accessibility for users with disabilities by providing an alternative to the mouse.",
             "items": {
               "$ref": "#/definitions/extensionKeyboardShortcut"
             },
@@ -1614,7 +1716,7 @@
         },
         "additionalProperties": false
       },
-      "additionalProperties": false
+        "additionalProperties": false
     },
     "requirementsExtensionElement": {
       "description": "Specifies limitations on which clients the add-in can be installed on, including limitations on the Office host application, the form factors, and the requirement sets that the client must support.",
@@ -1650,7 +1752,7 @@
         },
         "scopes": {
           "type": "array",
-          "description": "Identifies the scopes in which the add-in can run. Supported values: 'mail', 'workbook', 'document', 'presentation'.",
+          "description": "Identifies the scopes in which the add-in can run. Supported values: \u0027mail\u0027, \u0027workbook\u0027, \u0027document\u0027, \u0027presentation\u0027.",
           "minItems": 1,
           "maxItems": 4,
           "items": {
@@ -1677,7 +1779,7 @@
           }
         }
       },
-      "additionalProperties": false
+            "additionalProperties": false
     },
     "extensionRuntimesArray": {
       "type": "array",
@@ -1695,7 +1797,7 @@
             "description": "A unique identifier for this runtime within the app.  Maximum length is 64 characters.",
             "maxLength": 64
           },
-          "type": {
+            "type": {
             "type": "string",
             "enum": [
               "general"
@@ -1764,7 +1866,7 @@
       },
       "additionalProperties": false
     },
-    "enum": {
+          "enum": {
       "type": "object",
       "properties": {
         "id": {
@@ -1774,13 +1876,11 @@
           "minLength": 3,
           "pattern": "^[A-Za-z][A-Za-z0-9._]*$"
         },
-        "type": {
+          "type": {
           "type": "string",
           "description": "The type of the values in this enum.",
-          "enum": [
-            "number",
-            "string"
-          ]
+          "enum": [ "number", "string"
+ ]
         },
         "values": {
           "type": "array",
@@ -1794,10 +1894,8 @@
                 "maxLength": 256
               },
               "numberValue": {
-                "type": [
-                  "number",
-                  "null"
-                ],
+                "type": [ "number", "null"
+ ],
                 "description": "When enum type is number, the actual number value of the constant."
               },
               "stringValue": {
@@ -1811,18 +1909,17 @@
               }
             },
             "additionalProperties": false,
-            "required": [
-              "name"
-            ]
+            "required": [ "name"
+ ]
           }
         }
       },
-      "required": [
+            "required": [
         "id",
         "type",
         "values"
       ],
-      "additionalProperties": false
+            "additionalProperties": false
     },
     "extensionCustomFunctionsNamespace": {
       "type": "object",
@@ -1861,15 +1958,15 @@
         "name": {
           "type": "string",
           "pattern": "^[\\p{L}][\\p{L}0-9._]*$",
-          "description": "The name of the function that end users see in Excel. In Excel, this function name is prefixed by the custom functions namespace that's specified in the manifest file.",
+          "description": "The name of the function that end users see in Excel. In Excel, this function name is prefixed by the custom functions namespace that\u0027s specified in the manifest file.",
           "minLength": 3,
           "maxLength": 64
         },
-        "description": {
+          "description": {
           "type": "string",
           "description": "The description of the function that end users see in Excel.",
           "minLength": 1,
-          "maxLength": 128
+          "maxLength": 1024
         },
         "helpUrl": {
           "type": "string",
@@ -1897,47 +1994,47 @@
         },
         "volatile": {
           "type": "boolean",
-          "description": "If true, the function recalculates each time Excel recalculates, instead of only when the formula's dependent values have changed. A function can't use both the stream and volatile properties. If the stream and volatile properties are both set to true, the volatile property will be ignored.",
+          "description": "If true, the function recalculates each time Excel recalculates, instead of only when the formula\u0027s dependent values have changed. A function can\u0027t use both the stream and volatile properties. If the stream and volatile properties are both set to true, the volatile property will be ignored.",
           "default": false
         },
         "cancelable": {
           "type": "boolean",
-          "description": "If true, Excel calls the CancelableInvocation handler whenever the user takes an action that has the effect of canceling the function; for example, manually triggering recalculation or editing a cell that is referenced by the function. Cancelable functions are typically only used for asynchronous functions that return a single result and need to handle the cancellation of a request for data. A function can't use both the stream and cancelable properties.",
+          "description": "If true, Excel calls the CancelableInvocation handler whenever the user takes an action that has the effect of canceling the function; for example, manually triggering recalculation or editing a cell that is referenced by the function. Cancelable functions are typically only used for asynchronous functions that return a single result and need to handle the cancellation of a request for data. A function can\u0027t use both the stream and cancelable properties.",
           "default": false
         },
         "requiresAddress": {
           "type": "boolean",
-          "description": "If true, your custom function can access the address of the cell that invoked it. The address property of the invocation parameter contains the address of the cell that invoked your custom function. A function can't use both the stream and requiresAddress properties.",
+          "description": "If true, your custom function can access the address of the cell that invoked it. The address property of the invocation parameter contains the address of the cell that invoked your custom function. A function can\u0027t use both the stream and requiresAddress properties.",
           "default": false
         },
         "requiresParameterAddress": {
           "type": "boolean",
-          "description": "If true, your custom function can access the addresses of the function's input parameters. This property must be used in combination with the dimensionality property of the result object, and dimensionality must be set to matrix.",
+          "description": "If true, your custom function can access the addresses of the function\u0027s input parameters. This property must be used in combination with the dimensionality property of the result object, and dimensionality must be set to matrix.",
           "default": false
         },
         "requiresStreamAddress": {
           "type": "boolean",
           "default": false,
-          "description": "If `true`, the function can access the address of the cell calling the streaming function. The `address` property of the invocation parameter contains the address of the cell that invoked your streaming function. "
+          "description": "If \u0060true\u0060, the function can access the address of the cell calling the streaming function. The \u0060address\u0060 property of the invocation parameter contains the address of the cell that invoked your streaming function. "
         },
         "requiresStreamParameterAddresses": {
           "type": "boolean",
-          "description": "If `true`, the function can access the parameter addresses of the cell calling the streaming function. The `parameterAddresses` property of the invocation parameter contains the parameter addresses for your streaming function.",
+          "description": "If \u0060true\u0060, the function can access the parameter addresses of the cell calling the streaming function. The \u0060parameterAddresses\u0060 property of the invocation parameter contains the parameter addresses for your streaming function.",
           "default": false
         },
         "capturesCallingObject": {
           "type": "boolean",
-          "description": "If `true`, the data type being referenced by the custom function is passed as the first argument to the custom function.",
+          "description": "If \u0060true\u0060, the data type being referenced by the custom function is passed as the first argument to the custom function.",
           "default": false
         },
         "excludeFromAutoComplete": {
           "type": "boolean",
-          "description": "If `true`, the custom function will not appear in the formula AutoComplete menu in Excel.",
+          "description": "If \u0060true\u0060, the custom function will not appear in the formula AutoComplete menu in Excel.",
           "default": false
         },
         "linkedEntityLoadService": {
           "type": "boolean",
-          "description": "If `true`, it designates that the function is a linked entity load service that returns linked entity cell values for linked entity IDs requested by Excel.",
+          "description": "If \u0060true\u0060, it designates that the function is a linked entity load service that returns linked entity cell values for linked entity IDs requested by Excel.",
           "default": false
         }
       },
@@ -1953,21 +2050,21 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "The name of the parameter. This name is displayed in Excel's IntelliSense.",
+          "description": "The name of the parameter. This name is displayed in Excel\u0027s IntelliSense.",
           "minLength": 1,
           "maxLength": 64
         },
-        "description": {
+          "description": {
           "type": "string",
-          "description": "A description of the parameter. This is displayed in Excel's IntelliSense.",
+          "description": "A description of the parameter. This is displayed in Excel\u0027s IntelliSense.",
           "minLength": 1,
-          "maxLength": 128
+          "maxLength": 512
         },
-        "type": {
+          "type": {
           "type": "string",
           "minLength": 1,
           "maxLength": 128,
-          "description": "The data type of the parameter. It can only be 'boolean', 'number', 'string', 'any', 'CustomFunctions.Invocation', 'CustomFunctions.StreamingInvocation' or 'CustomFunctions.CancelableInvocation', 'any' allows you to use any of other types.",
+          "description": "The data type of the parameter. It can only be \u0027boolean\u0027, \u0027number\u0027, \u0027string\u0027, \u0027any\u0027, \u0027CustomFunctions.Invocation\u0027, \u0027CustomFunctions.StreamingInvocation\u0027 or \u0027CustomFunctions.CancelableInvocation\u0027, \u0027any\u0027 allows you to use any of other types.",
           "default": "any"
         },
         "cellValueType": {
@@ -1998,13 +2095,11 @@
         "customEnumId": {
           "type": "string",
           "maxLength": 64,
-          "description": "|The `id` of the enum in the `enums` array. This associates the custom enum with the function and enables Excel to display the enum members in the formula AutoComplete menu."
+          "description": "|The \u0060id\u0060 of the enum in the \u0060enums\u0060 array. This associates the custom enum with the function and enables Excel to display the enum members in the formula AutoComplete menu."
         },
         "optional": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": [ "boolean", "null"
+ ],
           "description": "If true, the parameter is optional."
         },
         "repeating": {
@@ -2013,9 +2108,8 @@
           "description": "If true, parameters populate from a specified array. Note that functions all repeating parameters are considered optional parameters by definition."
         }
       },
-      "required": [
-        "name"
-      ]
+      "required": [ "name"
+ ]
     },
     "extensionResult": {
       "type": "object",
@@ -2050,7 +2144,7 @@
           "description": "Identifier for this action. Maximum length is 64 characters. This value is passed to the code file.",
           "maxLength": 64
         },
-        "type": {
+          "type": {
           "type": "string",
           "enum": [
             "executeFunction",
@@ -2184,7 +2278,7 @@
             "align"
           ]
         },
-        "builtInTabId": {
+            "builtInTabId": {
           "type": "string",
           "description": "Id of the existing office Tab. Maximum length is 64 characters.",
           "maxLength": 64
@@ -2212,7 +2306,7 @@
           "description": "KeyTip shortcut for keyboard navigation (1-3 uppercase alphanumeric characters)",
           "minLength": 1,
           "maxLength": 3,
-          "pattern": "^[A-Z0-9]+$"
+          "pattern": "^[A-Z0-9]\u002B$"
         }
       },
       "dependencies": {
@@ -2226,13 +2320,12 @@
               }
             }
           },
-          "required": [
-            "builtInTabId"
-          ]
+          "required": [ "builtInTabId"
+ ]
         },
         "id": {
           "anyOf": [
-            {
+    {
               "required": [
                 "id",
                 "label",
@@ -2249,7 +2342,7 @@
           ]
         }
       },
-      "additionalProperties": false
+          "additionalProperties": false
     },
     "extensionRibbonsCustomTabGroupsItem": {
       "type": "object",
@@ -2266,8 +2359,8 @@
         },
         "icons": {
           "type": "array",
-          "minItems": 1,
-          "maxItems": 3,
+          "minItems": 3,
+          "maxItems": 8,
           "items": {
             "$ref": "#/definitions/extensionCommonIcon"
           }
@@ -2309,8 +2402,8 @@
         "icons": {
           "type": "array",
           "description": "Displayed icons for the group.",
-          "minItems": 1,
-          "maxItems": 3,
+          "minItems": 3,
+          "maxItems": 8,
           "items": {
             "$ref": "#/definitions/extensionCommonIcon"
           }
@@ -2341,7 +2434,7 @@
           "description": "A unique identifier for this control within the app. Maximum length is 64 characters. ",
           "maxLength": 64
         },
-        "type": {
+          "type": {
           "type": "string",
           "description": "Defines the type of control whether button or menu.",
           "enum": [
@@ -2362,8 +2455,8 @@
         "icons": {
           "type": "array",
           "description": "Configures the icons for the custom control.",
-          "minItems": 1,
-          "maxItems": 3,
+          "minItems": 3,
+          "maxItems": 8,
           "items": {
             "$ref": "#/definitions/extensionCommonIcon"
           }
@@ -2386,7 +2479,7 @@
           "description": "Whether the control is initially enabled.",
           "default": true
         },
-        "items": {
+          "items": {
           "type": "array",
           "description": "Configures the items for a menu control.",
           "minItems": 1,
@@ -2400,7 +2493,7 @@
           "description": "KeyTip shortcut for keyboard navigation (1-3 uppercase alphanumeric characters)",
           "minLength": 1,
           "maxLength": 3,
-          "pattern": "^[A-Z0-9]+$"
+          "pattern": "^[A-Z0-9]\u002B$"
         }
       },
       "required": [
@@ -2447,7 +2540,7 @@
           "description": "A unique identifier for this control within the app. Maximum length is 64 characters. ",
           "maxLength": 64
         },
-        "type": {
+          "type": {
           "type": "string",
           "description": "Supported values: menuItem.",
           "enum": [
@@ -2461,8 +2554,8 @@
         },
         "icons": {
           "type": "array",
-          "minItems": 1,
-          "maxItems": 3,
+          "minItems": 3,
+          "maxItems": 8,
           "items": {
             "$ref": "#/definitions/extensionCommonIcon"
           }
@@ -2489,7 +2582,7 @@
           "description": "KeyTip shortcut for keyboard navigation (1-3 uppercase alphanumeric characters)",
           "minLength": 1,
           "maxLength": 3,
-          "pattern": "^[A-Z0-9]+$"
+          "pattern": "^[A-Z0-9]\u002B$"
         }
       },
       "additionalProperties": false,
@@ -2510,7 +2603,7 @@
           "description": "A unique identifier for this control within the app. Maximum length is 64 characters. ",
           "maxLength": 64
         },
-        "type": {
+          "type": {
           "type": "string",
           "description": "Defines the type of control.",
           "enum": [
@@ -2563,14 +2656,14 @@
           "description": "Specifies the custom title of the preprocessing dialog.",
           "maxLength": 128
         },
-        "description": {
+          "description": {
           "type": "string",
           "description": "Specifies the custom text that appears in the preprocessing dialog.",
           "maxLength": 250
         },
         "spamNeverShowAgainOption": {
           "type": "boolean",
-          "description": "Indicating if the developer will allow the user to permanently bypass the PreProcessing Dialog for this add-in. \"false\" is the default value if not specified.",
+          "description": "Indicating if the developer will allow the user to permanently bypass the PreProcessing Dialog for this add-in. \u0022false\u0022 is the default value if not specified.",
           "default": "false"
         },
         "spamReportingOptions": {
@@ -2591,13 +2684,11 @@
                 "maxItems": 5
               }
             },
-            "type": {
+              "type": {
               "type": "string",
-              "enum": [
-                "radio",
-                "checkbox"
-              ],
-              "description": "Can be set to \"radio\" or \"checkbox\". This determines if Radio Buttons or checkboxes are used for the options. \"checkbox\" is the default if this value is not specified.",
+              "enum": [ "radio", "checkbox"
+ ],
+              "description": "Can be set to \u0022radio\u0022 or \u0022checkbox\u0022. This determines if Radio Buttons or checkboxes are used for the options. \u0022checkbox\u0022 is the default if this value is not specified.",
               "default": "checkbox"
             }
           },
@@ -2608,7 +2699,7 @@
         },
         "spamFreeTextSectionTitle": {
           "type": "string",
-          "description": "A text box to the preprocessing dialog to allow users to provide additional information on the message they're reporting. This value is the title of that text box.",
+          "description": "A text box to the preprocessing dialog to allow users to provide additional information on the message they\u0027re reporting. This value is the title of that text box.",
           "maxLength": 128
         },
         "spamMoreInfo": {
@@ -2632,7 +2723,7 @@
           ]
         }
       },
-      "required": [
+          "required": [
         "title",
         "description"
       ]
@@ -2645,11 +2736,10 @@
           "description": "Specify the Id of the button like msgReadFunctionButton.",
           "maxLength": 250
         },
-        "type": {
+          "type": {
           "type": "string",
-          "enum": [
-            "mobileButton"
-          ]
+          "enum": [ "mobileButton"
+ ]
         },
         "label": {
           "type": "string",
@@ -2684,11 +2774,8 @@
         "size": {
           "type": "number",
           "description": "Size in pixels of the icon. Three image sizes are required (25, 32, and 48 pixels).",
-          "enum": [
-            25,
-            32,
-            48
-          ]
+          "enum": [ 25, 32, 48
+ ]
         },
         "url": {
           "$ref": "#/definitions/httpsUrl",
@@ -2697,11 +2784,8 @@
         "scale": {
           "type": "number",
           "description": "How to scale - 1,2,3 for each image. This attribute specifies the UIScreen.scale property for iOS devices.",
-          "enum": [
-            1,
-            2,
-            3
-          ]
+          "enum": [ 1, 2, 3
+ ]
         }
       },
       "additionalProperties": false,
@@ -2719,7 +2803,7 @@
           "description": "Title text of the super tip. Maximum length is 64 characters.",
           "maxLength": 64
         },
-        "description": {
+          "description": {
           "type": "string",
           "description": "Description of the super tip. Maximum length is 250 characters.",
           "maxLength": 250
@@ -2737,16 +2821,8 @@
         "size": {
           "type": "number",
           "description": "Size in pixels of the icon. Three image sizes are required (16, 32, and 80 pixels)",
-          "enum": [
-            16,
-            20,
-            24,
-            32,
-            40,
-            48,
-            64,
-            80
-          ]
+          "enum": [ 16, 20, 24, 32, 40, 48, 64, 80
+ ]
         },
         "url": {
           "$ref": "#/definitions/httpsUrl",
@@ -2804,16 +2880,16 @@
                   ]
                 }
               },
-              "additionalProperties": false,
-              "required": [
+                  "additionalProperties": false,
+                  "required": [
                 "type",
                 "actionId"
               ]
             }
           }
         },
-        "additionalProperties": false,
-        "required": [
+                  "additionalProperties": false,
+                  "required": [
           "events"
         ]
       }
@@ -2964,9 +3040,9 @@
                     ]
                   }
                 },
-                "additionalProperties": false,
+                    "additionalProperties": false,
                 "anyOf": [
-                  {
+    {
                     "required": [
                       "effect",
                       "comAddin"
@@ -3006,8 +3082,8 @@
             ]
           }
         },
-        "minProperties": 1,
-        "additionalProperties": false
+            "minProperties": 1,
+                "additionalProperties": false
       }
     },
     "extensionXllCustomFunctions": {
@@ -3024,7 +3100,7 @@
     },
     "extensionContentRuntimeArray": {
       "type": "array",
-      "description": "Content runtime is for 'ContentApp', which can be embedded directly into Excel or PowerPoint documents.",
+      "description": "Content runtime is for \u0027ContentApp\u0027, which can be embedded directly into Excel or PowerPoint documents.",
       "minItems": 1,
       "items": {
         "type": "object",
@@ -3032,7 +3108,7 @@
           "requirements": {
             "type": "object",
             "$ref": "#/definitions/requirementsExtensionElement",
-            "description": "Specifies the Office requirement sets for content add-in runtime. If the user's Office version doesn't support the specified requirements, the component will not be available in that client."
+            "description": "Specifies the Office requirement sets for content add-in runtime. If the user\u0027s Office version doesn\u0027t support the specified requirements, the component will not be available in that client."
           },
           "id": {
             "type": "string",
@@ -3041,7 +3117,7 @@
           },
           "code": {
             "$ref": "#/definitions/extensionRuntimeCode",
-            "description": "Specifies the location of code for this runtime. Depending on the runtime.type, add-ins use either a JavaScript file or an HTML page with an embedded <script> tag that specifies the URL of a JavaScript file."
+            "description": "Specifies the location of code for this runtime. Depending on the runtime.type, add-ins use either a JavaScript file or an HTML page with an embedded \u003Cscript\u003E tag that specifies the URL of a JavaScript file."
           },
           "requestedHeight": {
             "type": "number",
@@ -3085,7 +3161,7 @@
             "description": "The title used for the top of the callout.",
             "maxLength": 125
           },
-          "description": {
+            "description": {
             "type": "string",
             "description": "The description/body content for the callout.",
             "maxLength": 250
@@ -3142,7 +3218,7 @@
           "maxItems": 20000
         },
         "keyMappingFiles": {
-          "description": "Specifies the full URLs for shortcuts mapping and localization resource files that don't directly support the unified manifest.",
+          "description": "Specifies the full URLs for shortcuts mapping and localization resource files that don\u0027t directly support the unified manifest.",
           "$ref": "#/definitions/keyboardShortcutsMappingFiles"
         }
       }
@@ -3153,16 +3229,15 @@
       "properties": {
         "shortcutsUrl": {
           "$ref": "#/definitions/httpsUrl",
-          "description": "The full URL of the JSON file that will contain the keyboard combination configuration on Office application and platform combinations that don't directly support the unified manifest."
+          "description": "The full URL of the JSON file that will contain the keyboard combination configuration on Office application and platform combinations that don\u0027t directly support the unified manifest."
         },
         "localizationResourceUrl": {
           "$ref": "#/definitions/httpsUrl",
           "description": "The full URL of a file that provides supplemental resource, such as localized strings, for the file specified in the shortcutsUrl attribute."
         }
       },
-      "required": [
-        "shortcutsUrl"
-      ]
+      "required": [ "shortcutsUrl"
+ ]
     },
     "extensionShortcut": {
       "type": "object",
@@ -3189,36 +3264,35 @@
       "properties": {
         "default": {
           "type": "string",
-          "description": "Fallback key for any platform that isn't specified.",
-          "pattern": "^[A-Za-z0-9-_+]+$",
+          "description": "Fallback key for any platform that isn\u0027t specified.",
+          "pattern": "^[A-Za-z0-9-_\u002B]\u002B$",
           "minLength": 1,
           "maxLength": 32
         },
         "mac": {
           "type": "string",
           "description": "key for mac platform. Alt is mapped to the Option key.",
-          "pattern": "^[A-Za-z0-9-_+]+$",
+          "pattern": "^[A-Za-z0-9-_\u002B]\u002B$",
           "minLength": 1,
           "maxLength": 32
         },
         "web": {
           "type": "string",
           "description": "key for web platform.",
-          "pattern": "^[A-Za-z0-9-_+]+$",
+          "pattern": "^[A-Za-z0-9-_\u002B]\u002B$",
           "minLength": 1,
           "maxLength": 32
         },
         "windows": {
           "type": "string",
           "description": "key for windows platform. Command is mapped to the Ctrl key.",
-          "pattern": "^[A-Za-z0-9-_+]+$",
+          "pattern": "^[A-Za-z0-9-_\u002B]\u002B$",
           "minLength": 1,
           "maxLength": 32
         }
       },
-      "required": [
-        "default"
-      ]
+      "required": [ "default"
+ ]
     },
     "extensionMenuItem": {
       "type": "array",
@@ -3229,7 +3303,7 @@
         "properties": {
           "entryPoint": {
             "type": "string",
-            "description": "Use 'text' or 'cell' here for Office context menu. Use 'text' if the context menu should open when a user right-clicks (selects and holds) on the selected text. Use 'cell' if the context menu should open when the user right-clicks (selects and holds) on a cell in an Excel spreadsheet.",
+            "description": "Use \u0027text\u0027 or \u0027cell\u0027 here for Office context menu. Use \u0027text\u0027 if the context menu should open when a user right-clicks (selects and holds) on the selected text. Use \u0027cell\u0027 if the context menu should open when the user right-clicks (selects and holds) on a cell in an Excel spreadsheet.",
             "enum": [
               "text",
               "cell"
@@ -3239,7 +3313,7 @@
             "type": "array",
             "items": {
               "$ref": "#/definitions/extensionCommonCustomGroupControlsItem",
-              "description": "The control type should be 'menu'. Minimum size is 1."
+              "description": "The control type should be \u0027menu\u0027. Minimum size is 1."
             },
             "minItems": 1
           }
@@ -3281,7 +3355,7 @@
           "description": "Represents the name of the card. Maximum length is 255 characters.",
           "maxLength": 255
         },
-        "description": {
+          "description": {
           "type": "string",
           "description": "Description of the card.Maximum length is 255 characters.",
           "maxLength": 255
@@ -3298,10 +3372,8 @@
         },
         "defaultSize": {
           "type": "string",
-          "enum": [
-            "medium",
-            "large"
-          ],
+          "enum": [ "medium", "large"
+ ],
           "description": "Rendering Size for dashboard card."
         }
       },
@@ -3317,7 +3389,7 @@
     },
     "dashboardCardIcon": {
       "type": "object",
-      "description": "Represents a configuration for the source of the card’s content",
+      "description": "Represents a configuration for the source of the card\u2019s content",
       "properties": {
         "iconUrl": {
           "type": "string",
@@ -3326,7 +3398,7 @@
         },
         "officeUIFabricIconName": {
           "type": "string",
-          "description": "Office UI Fabric/Fluent UI icon friendly name for the card. This value will be used if ‘iconUrl’ is not specified.",
+          "description": "Office UI Fabric/Fluent UI icon friendly name for the card. This value will be used if \u2018iconUrl\u2019 is not specified.",
           "maxLength": 255
         }
       },
@@ -3334,13 +3406,12 @@
     },
     "dashboardCardContentSource": {
       "type": "object",
-      "description": "Represents a configuration for the source of the card’s content.",
+      "description": "Represents a configuration for the source of the card\u2019s content.",
       "properties": {
         "sourceType": {
           "type": "string",
-          "enum": [
-            "bot"
-          ],
+          "enum": [ "bot"
+ ],
           "description": "The content of the dashboard card is sourced from a bot."
         },
         "botConfiguration": {
@@ -3355,7 +3426,7 @@
           "additionalProperties": false
         }
       },
-      "additionalProperties": false
+          "additionalProperties": false
     },
     "declarativeAgentRef": {
       "type": "object",
@@ -3369,7 +3440,7 @@
           "description": "Relative file path to this declarative agent element file in the application package."
         }
       },
-      "description": "A reference to a declarative agent element. The element's definition is in a separate file.",
+          "description": "A reference to a declarative agent element. The element\u0027s definition is in a separate file.",
       "required": [
         "id",
         "file"
@@ -3382,7 +3453,7 @@
         "id": {
           "type": "string",
           "description": "Unique identifier for the agentic user template. Must contain only alphanumeric characters, dots, underscores, and hyphens.",
-          "pattern": "^[a-zA-Z0-9._-]+$",
+          "pattern": "^[a-zA-Z0-9._-]\u002B$",
           "minLength": 1,
           "maxLength": 64
         },


### PR DESCRIPTION
## Summary

Updates the Teams App Manifest schema files to v1.27.

Generated by the App Manifest Schema Publisher.

## Changes from live

```
Mode: Direct Publish from teams-apppackagelibs
Source: v1_27_prod schema files
Exclusion rules: GA-schema-exclusions.txt (13 rules)
Base version: v1.26
Target version: v1.27
Files: 4

Exclusions applied to manifest schema:
  - authorization.permissions.orgWide being present
  - configurableTabs[i].supportedPlatform being present
  - copilotAgents.plugins being present
  - defaultGroupCapability.groupchat.enum member null being present
  - defaultGroupCapability.meetings.enum member null being present
  - defaultGroupCapability.team.enum member null being present
  - defaultInstallScope.enum member null being present
  - scopeConstraints being present
  - staticTabs[i].supportedPlatform being present
  - copilotAgents.customEngineAgents[i].functionsAs being present
  - copilotAgents.customEngineAgents[i].agenticUserTemplateId being present
  - definitions.pluginRef being present
  - definitions.copilotActionRef being present

Descriptions preserved from live schema: 27

Static schemas copied as-is from v1.26:
  - MicrosoftTeams.ResponseRenderingTemplate.schema.json
  - MicrosoftTeams.AgenticUser.schema.json
```